### PR TITLE
Simplify unused_music pack

### DIFF
--- a/src/main/resources/resourcepacks/unused_music/assets/minecraft/sounds.json
+++ b/src/main/resources/resourcepacks/unused_music/assets/minecraft/sounds.json
@@ -1,35 +1,7 @@
 {
   "music.creative": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music.game",
-        "type": "event"
-      },
-      {
-        "name": "music/game/creative/creative1",
-        "stream": true
-      },
-      {
-        "name": "music/game/creative/creative2",
-        "stream": true
-      },
-      {
-        "name": "music/game/creative/creative3",
-        "stream": true
-      },
-      {
-        "name": "music/game/creative/creative4",
-        "stream": true
-      },
-      {
-        "name": "music/game/creative/creative5",
-        "stream": true
-      },
-      {
-        "name": "music/game/creative/creative6",
-        "stream": true
-      },
       {
         "name": "mixtape:music/ki",
         "stream": true
@@ -45,81 +17,8 @@
     ]
   },
   "music.game": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/a_familiar_room",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/calm1",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true
-      },
-      {
-        "name": "music/game/comforting_memories",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/floating_dream",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -148,44 +47,8 @@
     ]
   },
   "music.menu": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/a_familiar_room",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/crescent_dunes",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/echo_in_the_wind",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/menu/menu1",
-        "stream": true
-      },
-      {
-        "name": "music/menu/menu2",
-        "stream": true
-      },
-      {
-        "name": "music/menu/menu3",
-        "stream": true
-      },
-      {
-        "name": "music/menu/menu4",
-        "stream": true
-      },
       {
         "name": "mixtape:music/beginning",
         "stream": true
@@ -197,30 +60,8 @@
     ]
   },
   "music.nether.basalt_deltas": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/nether/nether1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether2",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether3",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether4",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/soulsand_valley/so_below",
-        "stream": true,
-        "volume": 0.5,
-        "weight": 7
-      },
       {
         "name": "mixtape:music/excuse",
         "stream": true
@@ -228,30 +69,8 @@
     ]
   },
   "music.nether.crimson_forest": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/nether/crimson_forest/chrysopoeia",
-        "stream": true,
-        "volume": 0.5,
-        "weight": 7
-      },
-      {
-        "name": "music/game/nether/nether1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether2",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether3",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether4",
-        "stream": true
-      },
       {
         "name": "mixtape:music/excuse",
         "stream": true
@@ -259,30 +78,8 @@
     ]
   },
   "music.nether.nether_wastes": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/nether/nether1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether2",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether3",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether4",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether_wastes/rubedo",
-        "stream": true,
-        "volume": 0.5,
-        "weight": 6
-      },
       {
         "name": "mixtape:music/excuse",
         "stream": true
@@ -290,30 +87,8 @@
     ]
   },
   "music.nether.soul_sand_valley": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/nether/nether1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether2",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether3",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/nether4",
-        "stream": true
-      },
-      {
-        "name": "music/game/nether/soulsand_valley/so_below",
-        "stream": true,
-        "volume": 0.5,
-        "weight": 7
-      },
       {
         "name": "mixtape:music/excuse",
         "stream": true
@@ -321,60 +96,8 @@
     ]
   },
   "music.overworld.badlands": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/crescent_dunes",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/echo_in_the_wind",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -399,55 +122,8 @@
     ]
   },
   "music.overworld.bamboo_jungle": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -476,37 +152,8 @@
     ]
   },
   "music.overworld.cherry_grove": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/calm1",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true
-      },
-      {
-        "name": "music/game/echo_in_the_wind",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -531,43 +178,8 @@
     ]
   },
   "music.overworld.desert": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/crescent_dunes",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -592,39 +204,8 @@
     ]
   },
   "music.overworld.dripstone_caves": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/an_ordinary_day",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/infinite_amethyst",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/wending",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -649,47 +230,8 @@
     ]
   },
   "music.overworld.flower_forest": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/echo_in_the_wind",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -718,96 +260,8 @@
     ]
   },
   "music.overworld.forest": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/calm1",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true
-      },
-      {
-        "name": "music/game/comforting_memories",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/floating_dream",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
-      {
-        "name": "music/game/swamp/aerie",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/firebugs",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/labyrinthine",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -836,42 +290,8 @@
     ]
   },
   "music.overworld.frozen_peaks": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
-      {
-        "name": "music/game/stand_tall",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -879,47 +299,8 @@
     ]
   },
   "music.overworld.grove": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/calm1",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true
-      },
-      {
-        "name": "music/game/comforting_memories",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/infinite_amethyst",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
-      {
-        "name": "music/game/wending",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -944,51 +325,8 @@
     ]
   },
   "music.overworld.jagged_peaks": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/floating_dream",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
-      {
-        "name": "music/game/stand_tall",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/wending",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1008,54 +346,8 @@
     ]
   },
   "music.overworld.jungle": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1084,71 +376,8 @@
     ]
   },
   "music.overworld.lush_caves": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/an_ordinary_day",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/calm1",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/echo_in_the_wind",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/floating_dream",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 4
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true,
-        "weight": 2
-      },
-      {
-        "name": "music/game/swamp/aerie",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/firebugs",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/labyrinthine",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1161,35 +390,8 @@
     ]
   },
   "music.overworld.meadow": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1206,107 +408,8 @@
     ]
   },
   "music.overworld.old_growth_taiga": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/calm1",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/calm2",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/calm3",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/comforting_memories",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/floating_dream",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 3
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true,
-        "weight": 3
-      },
-      {
-        "name": "music/game/swamp/aerie",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/firebugs",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/labyrinthine",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1338,35 +441,8 @@
     ]
   },
   "music.overworld.snowy_slopes": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/an_ordinary_day",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/one_more_day",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/stand_tall",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1379,55 +455,8 @@
     ]
   },
   "music.overworld.sparse_jungle": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/bromeliad",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/left_to_bloom",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/nuance1",
-        "stream": true
-      },
-      {
-        "name": "music/game/nuance2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true
@@ -1456,47 +485,8 @@
     ]
   },
   "music.overworld.stony_peaks": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/hal1",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal2",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal3",
-        "stream": true
-      },
-      {
-        "name": "music/game/hal4",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano1",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano2",
-        "stream": true
-      },
-      {
-        "name": "music/game/piano3",
-        "stream": true
-      },
-      {
-        "name": "music/game/stand_tall",
-        "stream": true,
-        "volume": 0.4,
-        "weight": 2
-      },
-      {
-        "name": "music/game/wending",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/chris",
         "stream": true
@@ -1504,23 +494,8 @@
     ]
   },
   "music.overworld.swamp": {
-    "replace": true,
+    "replace": false,
     "sounds": [
-      {
-        "name": "music/game/swamp/aerie",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/firebugs",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/swamp/labyrinthine",
-        "stream": true,
-        "volume": 0.4
-      },
       {
         "name": "mixtape:music/kyoto",
         "stream": true


### PR DESCRIPTION
Change all the `"replace": true`'s to `false`, which lets us remove all the vanilla music specifications. Also improves compatibility with other music packs, because it won't overwrite them if it's above them (my motivation for this). This is only possible for this pack because it only adds music.